### PR TITLE
Add support to map external links to relative local links

### DIFF
--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         def load(self, file: Any, *args: Any, **kwargs: Any) -> Any: ...
         def loads(self, data: Any, *args: Any, **kwargs: Any) -> Any: ...
 
-__version__ = '2.0.0+Linaro-241028'
+__version__ = '2.0.0+Linaro-250508'
 __version_info__ = (2, 0, 0)
 
 package_dir = path.abspath(path.dirname(__file__))

--- a/sphinxcontrib/serializinghtml/html_assists.py
+++ b/sphinxcontrib/serializinghtml/html_assists.py
@@ -115,12 +115,14 @@ def rewrite_hub_links(html: str, link_mappings: dict) -> str:
     links = soup.find_all('a')
     for link in links:
         for key in link_mappings:
+            # Check if the href starts with the key
             if link['href'].startswith(key):
                 # We have a match, so replace the href with the new one
                 link['href'] = link['href'].replace(key, link_mappings[key])
                 # We also have to remove ".html" from the end of the link
                 link['href'] = link['href'].replace(".html", "")
                 edited = True
+                break
 
     if edited:
         html = str(soup)


### PR DESCRIPTION
Define a new configuration entry that is a dict of external and local links.

Add new function that goes through all of the `a` tags, looking to map those links.
